### PR TITLE
Fix blockquote TextStyle rendering in flutter_markdown

### DIFF
--- a/packages/flutter_markdown/CHANGELOG.md
+++ b/packages/flutter_markdown/CHANGELOG.md
@@ -1,3 +1,7 @@
+## NEXT
+
+* Fix for `blockquote` property not being applied in `MarkdownBody` widget.
+
 ## 0.7.6+2
 
 * Updates README to indicate that this package will be discontinued.

--- a/packages/flutter_markdown/lib/src/builder.dart
+++ b/packages/flutter_markdown/lib/src/builder.dart
@@ -364,7 +364,7 @@ class MarkdownBuilder implements md.NodeVisitor {
       child = _buildRichText(
         TextSpan(
           style: _isInBlockquote
-              ? styleSheet.blockquote!.merge(_inlines.last.style)
+              ? _inlines.last.style!.merge(styleSheet.blockquote)
               : _inlines.last.style,
           text: trimText(text.text),
           recognizer: _linkHandlers.isNotEmpty ? _linkHandlers.last : null,


### PR DESCRIPTION
This pull request resolves an issue where custom `TextStyle` properties applied through MarkdownStyleSheet were not being applied to blockquote elements when using `flutter_markdown`.

### Changes Made
- Inverted the style merging logic for blockquotes to ensure custom TextStyles are applied.

### Testing
- Verified that TextStyle now applies correctly to blockquote elements, including color, font size, and weight.