### PR TITLE
Add RTL text rendering support for blockquote in flutter_markdown

### DIFF
--- a/packages/flutter_markdown/lib/src/builder.dart
+++ b/packages/flutter_markdown/lib/src/builder.dart
@@ -980,6 +980,23 @@ class MarkdownBuilder implements md.NodeVisitor {
   Widget _buildRichText(TextSpan text, {TextAlign? textAlign, String? key}) {
     //Adding a unique key prevents the problem of using the same link handler for text spans with the same text
     final Key k = key == null ? UniqueKey() : Key(key);
+
+    if (selectable && _isInBlockquote) {
+      return SizedBox(
+        width: double.infinity,
+        child: SelectableText.rich(
+          text,
+          textScaler: styleSheet.textScaler,
+          textAlign: textAlign ?? TextAlign.start,
+          onSelectionChanged: onSelectionChanged != null
+              ? (TextSelection selection, SelectionChangedCause? cause) =>
+                  onSelectionChanged!(text.text, selection, cause)
+              : null,
+          onTap: onTapText,
+          key: k,
+        ),
+      );
+    }
     if (selectable) {
       return SelectableText.rich(
         text,
@@ -991,6 +1008,16 @@ class MarkdownBuilder implements md.NodeVisitor {
             : null,
         onTap: onTapText,
         key: k,
+      );
+    } else if (_isInBlockquote) {
+      return SizedBox(
+        width: double.infinity,
+        child: Text.rich(
+          text,
+          textScaler: styleSheet.textScaler,
+          textAlign: textAlign ?? TextAlign.start,
+          key: k,
+        ),
       );
     } else {
       return Text.rich(


### PR DESCRIPTION
This pull request attempts to fix the RTL text rendering in flutter_markdown by making the blockquote widget fill the entire width of its parent. The goal is to fix the weird behavior of single-line RTL quotes.

### Changes Made
- Added checks for blockquotes in `_buildRichText`.
- Wrapped rich text inside blockquote with a SizedBox that fills the entire width.

### Testing
- Verified that RTL blockquotes are rendered properly.